### PR TITLE
feat: Add onPageChange event emitter to BrowserService and update Fav…

### DIFF
--- a/src/app/browser.service.ts
+++ b/src/app/browser.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, EventEmitter } from '@angular/core';
 
 @Injectable({
     providedIn: 'root'
@@ -12,6 +12,8 @@ export class BrowserService {
 
     // @ts-ignore
     electronAPI = window.electronAPI;
+
+    public onPageChange: EventEmitter<{ url: string, title: string }> = new EventEmitter();
 
     captureScreen(rect?: { x: number, y: number, width: number, height: number }) {
         this.electronAPI.captureScreen(rect);
@@ -37,7 +39,10 @@ export class BrowserService {
 
     goToPage(url: string) {
         this.electronAPI.goToPage(url)
-            .then(() => this.updateHistory());
+            .then(() => {
+                this.updateHistory();
+                this.emitPageChange();
+            });
     }
 
     currentUrl(): Promise<{ url: string, title: string }> {
@@ -49,6 +54,7 @@ export class BrowserService {
             .then((data: { url: string, title: string }) => {
                 this.url = data.url;
                 this.title = data.title;
+                this.emitPageChange();
             });
         this.currentUrl().then(data => { console.log('currentUrl', data); });
     }
@@ -61,5 +67,9 @@ export class BrowserService {
 
         this.electronAPI.canGoForward()
             .then((canGoForward: boolean) => this.canGoForward = canGoForward);
+    }
+
+    emitPageChange() {
+        this.onPageChange.emit({ url: this.url, title: this.title });
     }
 }

--- a/src/app/components/favorite/favorite.component.html
+++ b/src/app/components/favorite/favorite.component.html
@@ -4,6 +4,7 @@
             <button>{{ favori.name }}</button>
         </li>
     </ul>
+    {{ currentSite.name }}
     <button mat-icon-button (click)="toggleFavorite()">
         <mat-icon aria-hidden="false" aria-label="Add to favorite">
             {{ isFavorite() ? 'star' : 'star_border' }}

--- a/src/app/components/favorite/favorite.component.ts
+++ b/src/app/components/favorite/favorite.component.ts
@@ -28,6 +28,11 @@ export class FavoriteComponent implements OnInit {
 
     console.log('favoris', this.favoris);
     this.updateCurrentSite();
+
+    this.browserService.onPageChange.subscribe((data: { url: string, title: string }) => {
+      this.updateCurrentSite();
+    });
+
   }
 
   updateCurrentSite() {


### PR DESCRIPTION
…oriteComponent

- Add onPageChange event emitter to BrowserService to emit page change events with the URL and title.
- Update FavoriteComponent to subscribe to the onPageChange event and update the current site accordingly.